### PR TITLE
more correct syntax for tagged releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Publish
 on:
     # Only on merges into main
     push:
-        tags: v*
+        tags: 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
     publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,12 +3,11 @@ name: Publish
 on:
     # Only on merges into main
     push:
-        branches:
-        -   main
+        tags:
+            'v*'
 
 jobs:
     publish:
-        if: startsWith(github.ref, 'refs/tags/v') # Only if tagged
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Publish
 on:
     # Only on merges into main
     push:
-        tags: 'v[0-9]+.[0-9]+.[0-9]+'
+        tags: v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
     publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,8 +3,7 @@ name: Publish
 on:
     # Only on merges into main
     push:
-        tags:
-            'v*'
+        tags: v*
 
 jobs:
     publish:


### PR DESCRIPTION
This should be less convoluted and build the release on a tag in `v*` format. It won't work if the tag has a `/`. For that we'd need `**`