### PR TITLE
minimal plugin system ideas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ Jinja2 = "^3.1.2"
 rich = "^12.3.0"
 rich-click = {extras = ["typer"], version = "^1.3.0"}
 typer = "^0.4.1"
+pluggy = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
 coverage = "^6.3.2"

--- a/src/pyscript/__init__.py
+++ b/src/pyscript/__init__.py
@@ -6,6 +6,15 @@ except ImportError:  # pragma: no cover
     import importlib_metadata as metadata  # type: ignore
 
 try:
+    import rich_click.typer as typer
+except ImportError:  # pragma: no cover
+    import typer  # type: ignore
+from rich.console import Console
+
+try:
     __version__ = metadata.version("pyscript-cli")
 except metadata.PackageNotFoundError:  # pragma: no cover
     __version__ = "unknown"
+
+console = Console()
+app = typer.Typer(add_completion=False)

--- a/src/pyscript/cli.py
+++ b/src/pyscript/cli.py
@@ -7,12 +7,13 @@ from typing import Any, Optional
 
 from pluggy import PluginManager
 
-from pyscript import __version__, app, console, typer
-from pyscript.plugins import hookspecs, _add_cmd
 import pyscript.plugins
+from pyscript import __version__, app, console, typer
 from pyscript._generator import file_to_html, string_to_html
+from pyscript.plugins import _add_cmd, hookspecs
 
-DEFAULT_PLUGINS = ['create', 'delete']
+DEFAULT_PLUGINS = ["create", "delete"]
+
 
 def _print_version():
     console.print(f"PyScript CLI version: {__version__}", style="bold green")

--- a/src/pyscript/cli.py
+++ b/src/pyscript/cli.py
@@ -8,6 +8,7 @@ from typing import Any, Optional
 from pluggy import PluginManager
 
 from pyscript import plugins
+from pyscript.plugins import hookspecs
 from pyscript import __version__, app, console, typer
 from pyscript._generator import file_to_html, string_to_html
 
@@ -108,7 +109,7 @@ def wrap(
 
 pm = PluginManager("pyscript-cli")
 
-pm.add_hookspecs(plugins.hookspecs)
+pm.add_hookspecs(hookspecs)
 
 for modname in DEFAULT_PLUGINS:
     importspec = f"pyscript.plugins.{modname}"
@@ -124,7 +125,7 @@ for modname in DEFAULT_PLUGINS:
         mod = sys.modules[importspec]
         pm.register(mod, modname)
 
-    pm.load_setuptools_entrypoints("pyscript-cli")
+    loaded = pm.load_setuptools_entrypoints("pyscript-cli")
 
 for cmd in pm.hook.pyscript_subcommand():
     plugins._add_cmd(cmd)

--- a/src/pyscript/cli.py
+++ b/src/pyscript/cli.py
@@ -7,10 +7,9 @@ from typing import Any, Optional
 
 from pluggy import PluginManager
 
-from pyscript import plugins
-from pyscript.plugins import hookspecs
-from pyscript import __version__, app, console, typer
+from pyscript import __version__, app, console, plugins, typer
 from pyscript._generator import file_to_html, string_to_html
+from pyscript.plugins import hookspecs
 
 DEFAULT_PLUGINS = ["create", "delete"]
 

--- a/src/pyscript/cli.py
+++ b/src/pyscript/cli.py
@@ -7,10 +7,9 @@ from typing import Any, Optional
 
 from pluggy import PluginManager
 
-import pyscript.plugins
+from pyscript import plugins
 from pyscript import __version__, app, console, typer
 from pyscript._generator import file_to_html, string_to_html
-from pyscript.plugins import _add_cmd, hookspecs
 
 DEFAULT_PLUGINS = ["create", "delete"]
 
@@ -109,7 +108,7 @@ def wrap(
 
 pm = PluginManager("pyscript-cli")
 
-pm.add_hookspecs(hookspecs)
+pm.add_hookspecs(plugins.hookspecs)
 
 for modname in DEFAULT_PLUGINS:
     importspec = f"pyscript.plugins.{modname}"
@@ -128,4 +127,4 @@ for modname in DEFAULT_PLUGINS:
     pm.load_setuptools_entrypoints("pyscript-cli")
 
 for cmd in pm.hook.pyscript_subcommand():
-    _add_cmd(cmd)
+    plugins._add_cmd(cmd)

--- a/src/pyscript/cli.py
+++ b/src/pyscript/cli.py
@@ -6,16 +6,11 @@ from typing import Any, Optional
 
 from pyscript._generator import file_to_html, string_to_html
 
-try:
-    import rich_click.typer as typer
-except ImportError:  # pragma: no cover
-    import typer  # type: ignore
-from rich.console import Console
 
-from pyscript import __version__
+from pluggy import PluginManager
 
-console = Console()
-app = typer.Typer(add_completion=False)
+from pyscript import __version__, app, console, typer
+from pyscript.plugins import create, delete, hookspecs, add_cmd
 
 
 def _print_version():
@@ -108,3 +103,13 @@ def wrap(
     if remove_output:
         time.sleep(1)
         output.unlink()
+
+pm = PluginManager("pyscript-cli")
+
+pm.add_hookspecs(hookspecs)
+
+pm.load_setuptools_entrypoints("pyscript-cli")
+pm.register(create)
+
+for cmd in pm.hook.register_cmd():
+    add_cmd(cmd)

--- a/src/pyscript/plugins/__init__.py
+++ b/src/pyscript/plugins/__init__.py
@@ -1,0 +1,13 @@
+from pluggy import HookimplMarker
+from pyscript import app
+
+hookimpl = HookimplMarker("pyscript-cli")
+
+def add_cmd(f):
+    print(f"registering {f.__name__}")
+    app.command()(f)
+
+
+@hookimpl
+def register_cmd(app, console):
+    pass

--- a/src/pyscript/plugins/__init__.py
+++ b/src/pyscript/plugins/__init__.py
@@ -4,5 +4,6 @@ from pyscript import app
 
 register = HookimplMarker("pyscript-cli")
 
+
 def _add_cmd(f):
     app.command()(f)

--- a/src/pyscript/plugins/__init__.py
+++ b/src/pyscript/plugins/__init__.py
@@ -1,13 +1,7 @@
 from pluggy import HookimplMarker
 from pyscript import app
 
-hookimpl = HookimplMarker("pyscript-cli")
+register = HookimplMarker("pyscript-cli")
 
-def add_cmd(f):
-    print(f"registering {f.__name__}")
+def _add_cmd(f):
     app.command()(f)
-
-
-@hookimpl
-def register_cmd(app, console):
-    pass

--- a/src/pyscript/plugins/create.py
+++ b/src/pyscript/plugins/create.py
@@ -1,0 +1,20 @@
+from pyscript import app, console
+from pyscript.plugins import add_cmd
+
+# @app.command()
+# def create():
+#     """Creates a new PyScript Project from scratch."""
+#     console.print(f"PyScript CLI MADE IT!", style="bold green")
+#     return True
+    
+from pyscript.plugins import hookimpl
+
+
+def create():
+    console.print(f"PyScript CLI MADE IT!", style="bold green")
+    return True
+
+@hookimpl
+def register_cmd():
+    return create   
+    

--- a/src/pyscript/plugins/create.py
+++ b/src/pyscript/plugins/create.py
@@ -1,20 +1,12 @@
-from pyscript import app, console
-from pyscript.plugins import add_cmd
-
-# @app.command()
-# def create():
-#     """Creates a new PyScript Project from scratch."""
-#     console.print(f"PyScript CLI MADE IT!", style="bold green")
-#     return True
-    
-from pyscript.plugins import hookimpl
+from pyscript import console, plugins
 
 
 def create():
-    console.print(f"PyScript CLI MADE IT!", style="bold green")
+    """Creates a new PyScript Project from scratch."""
+    console.print(f"pyscript create cmd not yet available..", style="bold green")
     return True
 
-@hookimpl
-def register_cmd():
+@plugins.register
+def pyscript_subcommand():
     return create   
     

--- a/src/pyscript/plugins/create.py
+++ b/src/pyscript/plugins/create.py
@@ -3,7 +3,7 @@ from pyscript import console, plugins
 
 def create():
     """Creates a new PyScript Project from scratch."""
-    console.print(f"pyscript create cmd not yet available..", style="bold green")
+    console.print("pyscript create cmd not yet available..", style="bold green")
     return True
 
 

--- a/src/pyscript/plugins/create.py
+++ b/src/pyscript/plugins/create.py
@@ -1,4 +1,3 @@
-
 from pyscript import console, plugins
 
 
@@ -6,6 +5,7 @@ def create():
     """Creates a new PyScript Project from scratch."""
     console.print(f"pyscript create cmd not yet available..", style="bold green")
     return True
+
 
 @plugins.register
 def pyscript_subcommand():

--- a/src/pyscript/plugins/delete.py
+++ b/src/pyscript/plugins/delete.py
@@ -6,6 +6,7 @@ def delete():
     console.print(f"pyscript delete cmd not yet available..", style="bold red")
     return True
 
+
 @register
 def pyscript_subcommand():
     return delete

--- a/src/pyscript/plugins/delete.py
+++ b/src/pyscript/plugins/delete.py
@@ -1,7 +1,11 @@
-from pyscript import app, console
-from pyscript.plugins import add_cmd
+from pyscript import console
+from pyscript.plugins import register
 
-@add_cmd
+
 def delete():
-    console.print(f"PyScript DELETED IT!", style="bold red")
+    console.print(f"pyscript delete cmd not yet available..", style="bold red")
     return True
+
+@register
+def pyscript_subcommand():
+    return delete

--- a/src/pyscript/plugins/delete.py
+++ b/src/pyscript/plugins/delete.py
@@ -1,0 +1,7 @@
+from pyscript import app, console
+from pyscript.plugins import add_cmd
+
+@add_cmd
+def delete():
+    console.print(f"PyScript DELETED IT!", style="bold red")
+    return True

--- a/src/pyscript/plugins/delete.py
+++ b/src/pyscript/plugins/delete.py
@@ -3,7 +3,7 @@ from pyscript.plugins import register
 
 
 def delete():
-    console.print(f"pyscript delete cmd not yet available..", style="bold red")
+    console.print("pyscript delete cmd not yet available..", style="bold red")
     return True
 
 

--- a/src/pyscript/plugins/hookspecs.py
+++ b/src/pyscript/plugins/hookspecs.py
@@ -1,0 +1,10 @@
+
+from pluggy import HookspecMarker
+
+hookspec = HookspecMarker("pyscript-cli")
+
+
+@hookspec
+def register_cmd():
+    """My special little hook that you can customize."""
+

--- a/src/pyscript/plugins/hookspecs.py
+++ b/src/pyscript/plugins/hookspecs.py
@@ -5,6 +5,6 @@ hookspec = HookspecMarker("pyscript-cli")
 
 
 @hookspec
-def register_cmd():
+def pyscript_subcommand():
     """My special little hook that you can customize."""
 


### PR DESCRIPTION
This is an implementation proposal for #23 . It uses `Pluggy` to allow creating new plugins that add a subcommand  by using the `@pyscript.plugins.register` decorator on a function hook that is called `pyscript_subcommand` . In this PR:

* `pyscript-cli` standard commands are implemented as `plugins` themselves (basically part of a `pyscript-cli` stdlib
* Plugins can register new commands by decorating a function that returns the new command function
* Plugins can be discovered using `setuptools entrypoints`. This is possible by adding `entry_points={"pyscript-cli": ["cmd_name = cmd_module"]}` to your setup.py file or  
```
[tool.poetry.plugins."pyscript-cli"]
hello = "pyscript_cli_hello"
```
 to your `toml` file if you are using Poetry.

I've tried adding a plugin through setuptools with the following structure:

```
/pyscript_cli_hello/__init__.py
/pyproject.toml
```

where ` /pyscript_cli_hello/__init__.py ` is :

```

__version__ = '0.1.0'


from pyscript import console, plugins


def hello():
    """SAY HELLO! in new PyScript Project from scratch."""
    console.print(f"Hello..", style="bold green")
    return True

@plugins.register
def pyscript_subcommand():
    return hello
```

and `/pyproject.toml` is:

```
[tool.poetry]
name = "pyscript-cli-hello"
version = "0.1.0"
description = ""
authors = ["Fabio Pliger"]

[tool.poetry.dependencies]
python = "^3.7"
importlib-metadata = {version = "^4.11.3", python = "3.7"}
Jinja2 = "^3.1.2"
rich = "^12.3.0"
rich-click = {extras = ["typer"], version = "^1.3.0"}
typer = "^0.4.1"
pluggy = "^1.0.0"
pyscript-cli = {path = "../../pyscript-cli", develop=true}


[tool.poetry.dev-dependencies]
coverage = "^6.3.2"
mypy = "^0.950"
pytest = "^7.1.2"

[build-system]
requires = ["poetry-core>=1.0.0"]
build-backend = "poetry.core.masonry.api"

[tool.poetry.plugins."pyscript-cli"]
hello = "pyscript_cli_hello"
```