### PR TITLE
Rename pyscript-cli -> pyscript.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A command-line interface for [PyScript](https://pyscript.net).
 
 
-[![Version](https://img.shields.io/pypi/v/pyscript-cli.svg)](https://pypi.org/project/pyscript-cli/)
+[![Version](https://img.shields.io/pypi/v/pyscript.svg)](https://pypi.org/project/pyscript/)
 [![Test](https://github.com/pyscript/pyscript-cli/actions/workflows/test.yml/badge.svg)](https://github.com/pyscript/pyscript-cli/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/pyscript/pyscript-cli/branch/main/graph/badge.svg?token=dCxt9oBQPL)](https://codecov.io/gh/pyscript/pyscript-cli)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/pyscript/pyscript-cli/main.svg)](https://results.pre-commit.ci/latest/github/pyscript/pyscript-cli/main)
@@ -16,7 +16,7 @@ Quickly wrap Python scripts into a HTML template, pre-configured with [PyScript]
 ## Installation
 
 ```shell
-$ pip install pyscript-cli
+$ pip install pyscript
 ```
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,16 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-name = "pyscript-cli"
-version = "0.2.1"
+name = "pyscript"
+version = "0.2.2"
 description = "Command Line Interface for PyScript"
-authors = ["Matt Kramer <mkramer@anaconda.com>"]
+authors = [
+    "Matt Kramer <mkramer@anaconda.com>",
+    "Fabio Pliger <fpliger@anaconda.com>",
+    "Nicholas Tollervey <ntollervey@anaconda.com>",
+]
 license = "Apache-2.0"
-repository = "https://github.com/mattkram/pyscript-cli"
+repository = "https://github.com/pyscript/pyscript-cli"
 readme = "README.md"
 packages = [
     { include = "pyscript", from = "src" },

--- a/src/pyscript/__init__.py
+++ b/src/pyscript/__init__.py
@@ -12,7 +12,7 @@ except ImportError:  # pragma: no cover
 from rich.console import Console
 
 try:
-    __version__ = metadata.version("pyscript-cli")
+    __version__ = metadata.version("pyscript")
 except metadata.PackageNotFoundError:  # pragma: no cover
     __version__ = "unknown"
 

--- a/src/pyscript/cli.py
+++ b/src/pyscript/cli.py
@@ -106,7 +106,7 @@ def wrap(
         output.unlink()
 
 
-pm = PluginManager("pyscript-cli")
+pm = PluginManager("pyscript")
 
 pm.add_hookspecs(hookspecs)
 
@@ -124,7 +124,7 @@ for modname in DEFAULT_PLUGINS:
         mod = sys.modules[importspec]
         pm.register(mod, modname)
 
-    loaded = pm.load_setuptools_entrypoints("pyscript-cli")
+    loaded = pm.load_setuptools_entrypoints("pyscript")
 
 for cmd in pm.hook.pyscript_subcommand():
     plugins._add_cmd(cmd)

--- a/src/pyscript/plugins/__init__.py
+++ b/src/pyscript/plugins/__init__.py
@@ -2,7 +2,7 @@ from pluggy import HookimplMarker
 
 from pyscript import app
 
-register = HookimplMarker("pyscript-cli")
+register = HookimplMarker("pyscript")
 
 
 def _add_cmd(f):

--- a/src/pyscript/plugins/hookspecs.py
+++ b/src/pyscript/plugins/hookspecs.py
@@ -1,6 +1,6 @@
 from pluggy import HookspecMarker
 
-hookspec = HookspecMarker("pyscript-cli")
+hookspec = HookspecMarker("pyscript")
 
 
 @hookspec


### PR DESCRIPTION
This PR introduces a single change. The package name is changed from `pyscript-cli` to `pyscript`.

**TODO**: Register `pyscript` on PyPI and remove `pyscript-cli`.