### PR TITLE
Ok call

### DIFF
--- a/src/pyscript/cli.py
+++ b/src/pyscript/cli.py
@@ -10,6 +10,17 @@ from pyscript.plugins import hookspecs
 DEFAULT_PLUGINS = ["create", "wrap"]
 
 
+def ok(msg=None):
+    """
+    Simply prints "OK" and an optional message, to the console, before cleanly
+    exiting.
+
+    Provides a standard way to end/confirm a successful command.
+    """
+    console.print(f"OK. {msg}", style="green")
+    raise typer.Exit()
+
+
 class Abort(typer.Abort):
     """
     Abort with a consistent error message.

--- a/src/pyscript/cli.py
+++ b/src/pyscript/cli.py
@@ -10,7 +10,7 @@ from pyscript.plugins import hookspecs
 DEFAULT_PLUGINS = ["create", "wrap"]
 
 
-def ok(msg: str=""):
+def ok(msg: str = ""):
     """
     Simply prints "OK" and an optional message, to the console, before cleanly
     exiting.

--- a/src/pyscript/cli.py
+++ b/src/pyscript/cli.py
@@ -10,14 +10,14 @@ from pyscript.plugins import hookspecs
 DEFAULT_PLUGINS = ["create", "wrap"]
 
 
-def ok(msg=None):
+def ok(msg: str=""):
     """
     Simply prints "OK" and an optional message, to the console, before cleanly
     exiting.
 
     Provides a standard way to end/confirm a successful command.
     """
-    console.print(f"OK. {msg}", style="green")
+    console.print(f"OK. {msg}".rstrip(), style="green")
     raise typer.Exit()
 
 


### PR DESCRIPTION
This PR (stacked upon #25) adds a single OK function:

* To be used to confirm success of a command.
* Displays optional message.
* Green signifies success.

Looks like this in action:

![ok](https://user-images.githubusercontent.com/37602/186431892-04d7c6c3-f928-445c-ab83-d9c47a785e0a.gif)
