### PR TITLE
No user generated UUID

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyscript"
-version = "0.2.2"
+version = "0.2.3"
 description = "Command Line Interface for PyScript"
 authors = [
     "Matt Kramer <mkramer@anaconda.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyscript"
-version = "0.2.3"
+version = "0.2.4"
 description = "Command Line Interface for PyScript"
 authors = [
     "Matt Kramer <mkramer@anaconda.com>",

--- a/src/pyscript/_generator.py
+++ b/src/pyscript/_generator.py
@@ -1,7 +1,6 @@
 import datetime
 from pathlib import Path
 from typing import Optional
-from uuid import uuid4
 
 import jinja2
 import toml
@@ -45,7 +44,6 @@ def create_project(
         "author_email": author_email,
         "version": f"{datetime.date.today().year}.1.1",
         "created_on": datetime.datetime.now(),
-        "id": str(uuid4()),
     }
     app_dir = Path(".") / app_name
     app_dir.mkdir()

--- a/src/pyscript/_generator.py
+++ b/src/pyscript/_generator.py
@@ -38,8 +38,9 @@ def create_project(
     TODO: more files to add to the core project start state.
     """
     context = {
-        "app_name": app_name,
-        "app_description": app_description,
+        "name": app_name,
+        "description": app_description,
+        "type": "app",
         "author_name": author_name,
         "author_email": author_email,
         "version": f"{datetime.date.today().year}.1.1",

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -26,8 +26,9 @@ def test_create_project(tmp_cwd: Path, is_not_none: Any) -> None:
         contents = toml.load(fp)
 
     assert contents == {
-        "app_name": "app_name",
-        "app_description": "A longer, human friendly, app description.",
+        "name": "app_name",
+        "description": "A longer, human friendly, app description.",
+        "type": "app",
         "author_name": "A.Coder",
         "author_email": "acoder@domain.com",
         "created_on": is_not_none,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -32,7 +32,6 @@ def test_create_project(tmp_cwd: Path, is_not_none: Any) -> None:
         "author_name": "A.Coder",
         "author_email": "acoder@domain.com",
         "created_on": is_not_none,
-        "id": is_not_none,
         "version": is_not_none,
     }
 


### PR DESCRIPTION
This small PR makes two minor adjustments:

* No user generated UUID is added to the `manifest.toml` file upon app creation.
* Revised unit tests to reflect this change.

The UUID is now generated by the API and this should be the single canonical source of such ids.