### PR TITLE
Add cross-platform config capabilities.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ sphinx-autobuild = {version = "^2021.3.14", optional = true}
 sphinx-autodoc-typehints = {version = "^1.19.2", optional = true}
 myst-parser = {version = "^0.18.0", optional = true}
 pydata-sphinx-theme = {version = "^0.9.0", optional = true}
+platformdirs = "^2.5.2"
 
 [tool.poetry.dev-dependencies]
 coverage = "^6.3.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyscript"
-version = "0.2.4"
+version = "0.2.5"
 description = "Command Line Interface for PyScript"
 authors = [
     "Matt Kramer <mkramer@anaconda.com>",

--- a/src/pyscript/__init__.py
+++ b/src/pyscript/__init__.py
@@ -1,9 +1,9 @@
 """A CLI for PyScript!"""
 from pathlib import Path
-from rich.console import Console
 
 import platformdirs
 import toml
+from rich.console import Console
 
 APPNAME = "pyscript"
 APPAUTHOR = "python"

--- a/src/pyscript/__init__.py
+++ b/src/pyscript/__init__.py
@@ -2,33 +2,37 @@
 import toml
 import platformdirs
 from pathlib import Path
+from rich.console import Console
 
 
 APPNAME = "pyscript"
 APPAUTHOR = "python"
 
+
 DATA_DIR = Path(platformdirs.user_data_dir(appname=APPNAME, appauthor=APPAUTHOR))
 CONFIG_FILE = DATA_DIR / Path("pyscript.toml")
-
 if not DATA_DIR.exists():
     DATA_DIR.mkdir(parents=True)
     CONFIG_FILE.touch(exist_ok=True)
+
 
 try:
     from importlib import metadata
 except ImportError:  # pragma: no cover
     import importlib_metadata as metadata  # type: ignore
 
+
 try:
     import rich_click.typer as typer
 except ImportError:  # pragma: no cover
     import typer  # type: ignore
-from rich.console import Console
+
 
 try:
     __version__ = metadata.version("pyscript")
 except metadata.PackageNotFoundError:  # pragma: no cover
     __version__ = "unknown"
+
 
 console = Console()
 app = typer.Typer(add_completion=False)

--- a/src/pyscript/__init__.py
+++ b/src/pyscript/__init__.py
@@ -1,8 +1,8 @@
 """A CLI for PyScript!"""
-import toml
-import platformdirs
 from pathlib import Path
 
+import platformdirs
+import toml
 
 APPNAME = "pyscript"
 APPAUTHOR = "python"
@@ -23,6 +23,7 @@ try:
     import rich_click.typer as typer
 except ImportError:  # pragma: no cover
     import typer  # type: ignore
+
 from rich.console import Console
 
 try:

--- a/src/pyscript/__init__.py
+++ b/src/pyscript/__init__.py
@@ -1,4 +1,18 @@
 """A CLI for PyScript!"""
+import toml
+import platformdirs
+from pathlib import Path
+
+
+APPNAME = "pyscript"
+APPAUTHOR = "python"
+
+DATA_DIR = Path(platformdirs.user_data_dir(appname=APPNAME, appauthor=APPAUTHOR))
+CONFIG_FILE = DATA_DIR / Path("pyscript.toml")
+
+if not DATA_DIR.exists():
+    DATA_DIR.mkdir(parents=True)
+    CONFIG_FILE.touch(exist_ok=True)
 
 try:
     from importlib import metadata
@@ -18,3 +32,4 @@ except metadata.PackageNotFoundError:  # pragma: no cover
 
 console = Console()
 app = typer.Typer(add_completion=False)
+config = toml.load(CONFIG_FILE)

--- a/src/pyscript/cli.py
+++ b/src/pyscript/cli.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 from pluggy import PluginManager
 
-from pyscript import __version__, app, console, plugins, typer, config
+from pyscript import __version__, app, console, plugins, typer
 from pyscript.plugins import hookspecs
 
 DEFAULT_PLUGINS = ["create", "wrap"]

--- a/src/pyscript/cli.py
+++ b/src/pyscript/cli.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 from pluggy import PluginManager
 
-from pyscript import __version__, app, console, plugins, typer, config
+from pyscript import __version__, app, config, console, plugins, typer
 from pyscript.plugins import hookspecs
 
 DEFAULT_PLUGINS = ["create", "wrap"]

--- a/src/pyscript/cli.py
+++ b/src/pyscript/cli.py
@@ -1,7 +1,9 @@
 """The main CLI entrypoint and commands."""
 import sys
 from typing import Any, Optional
+
 from pluggy import PluginManager
+
 from pyscript import __version__, app, console, plugins, typer
 from pyscript.plugins import hookspecs
 

--- a/src/pyscript/cli.py
+++ b/src/pyscript/cli.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 from pluggy import PluginManager
 
-from pyscript import __version__, app, console, plugins, typer
+from pyscript import __version__, app, console, plugins, typer, config
 from pyscript.plugins import hookspecs
 
 DEFAULT_PLUGINS = ["create", "wrap"]


### PR DESCRIPTION
This PR adds three simple changes:

* Use the `platformdirs` module to find the OS appropriate place to store a config file.
* If such a config file doesn't already exist, create one (currently empty). This is `pyscript.CONFIG_FILE`.
* Load the contents of the config file (TOML) and make it available to the app as `pyscript.config`.