### PR TITLE
Replace TOML with JSON for config in the command line.

### DIFF
--- a/src/pyscript/__init__.py
+++ b/src/pyscript/__init__.py
@@ -1,8 +1,8 @@
 """A CLI for PyScript!"""
+import json
 from pathlib import Path
 
 import platformdirs
-import json 
 from rich.console import Console
 
 APPNAME = "pyscript"

--- a/src/pyscript/__init__.py
+++ b/src/pyscript/__init__.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 
 import platformdirs
-import toml
+import json 
 from rich.console import Console
 
 APPNAME = "pyscript"
@@ -10,10 +10,11 @@ APPAUTHOR = "python"
 
 
 DATA_DIR = Path(platformdirs.user_data_dir(appname=APPNAME, appauthor=APPAUTHOR))
-CONFIG_FILE = DATA_DIR / Path("pyscript.toml")
-if not DATA_DIR.exists():
-    DATA_DIR.mkdir(parents=True)
-    CONFIG_FILE.touch(exist_ok=True)
+CONFIG_FILE = DATA_DIR / Path("config.json")
+if not CONFIG_FILE.is_file():
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    with CONFIG_FILE.open("w") as config_file:
+        json.dump({}, config_file)
 
 
 try:
@@ -36,4 +37,5 @@ except metadata.PackageNotFoundError:  # pragma: no cover
 
 console = Console()
 app = typer.Typer(add_completion=False)
-config = toml.load(CONFIG_FILE)
+with CONFIG_FILE.open() as config_file:
+    config = json.load(config_file)

--- a/src/pyscript/__init__.py
+++ b/src/pyscript/__init__.py
@@ -9,12 +9,19 @@ APPNAME = "pyscript"
 APPAUTHOR = "python"
 
 
+# Default initial data for the command line.
+DEFAULT_CONFIG = {
+    # Name of config file for PyScript projects.
+    "project_config_filename": "manifest.json",
+}
+
+
 DATA_DIR = Path(platformdirs.user_data_dir(appname=APPNAME, appauthor=APPAUTHOR))
 CONFIG_FILE = DATA_DIR / Path("config.json")
 if not CONFIG_FILE.is_file():
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     with CONFIG_FILE.open("w") as config_file:
-        json.dump({}, config_file)
+        json.dump(DEFAULT_CONFIG, config_file)
 
 
 try:

--- a/src/pyscript/_generator.py
+++ b/src/pyscript/_generator.py
@@ -1,9 +1,9 @@
 import datetime
+import json
 from pathlib import Path
 from typing import Optional
 
 import jinja2
-import json
 
 _env = jinja2.Environment(loader=jinja2.PackageLoader("pyscript"))
 

--- a/src/pyscript/_generator.py
+++ b/src/pyscript/_generator.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 import jinja2
-import toml
+import json
 
 _env = jinja2.Environment(loader=jinja2.PackageLoader("pyscript"))
 
@@ -31,7 +31,7 @@ def create_project(
     """
     New files created:
 
-    manifest.toml - project metadata
+    manifest.json - project metadata
     index.html - a "Hello world" start page for the project.
 
     TODO: more files to add to the core project start state.
@@ -43,12 +43,11 @@ def create_project(
         "author_name": author_name,
         "author_email": author_email,
         "version": f"{datetime.date.today().year}.1.1",
-        "created_on": datetime.datetime.now(),
     }
     app_dir = Path(".") / app_name
     app_dir.mkdir()
-    manifest_file = app_dir / "manifest.toml"
+    manifest_file = app_dir / "manifest.json"
     with manifest_file.open("w", encoding="utf-8") as fp:
-        toml.dump(context, fp)
+        json.dump(context, fp)
     index_file = app_dir / "index.html"
     string_to_html('print("Hello, world!")', app_name, index_file)

--- a/src/pyscript/_generator.py
+++ b/src/pyscript/_generator.py
@@ -2,6 +2,7 @@ import datetime
 import json
 from pathlib import Path
 from typing import Optional
+from pyscript import config
 
 import jinja2
 
@@ -46,7 +47,7 @@ def create_project(
     }
     app_dir = Path(".") / app_name
     app_dir.mkdir()
-    manifest_file = app_dir / "manifest.json"
+    manifest_file = app_dir / config["project_config_filename"]
     with manifest_file.open("w", encoding="utf-8") as fp:
         json.dump(context, fp)
     index_file = app_dir / "index.html"

--- a/src/pyscript/_generator.py
+++ b/src/pyscript/_generator.py
@@ -6,8 +6,6 @@ from pyscript import config
 
 import jinja2
 
-from pyscript import DEFAULT_CONFIG_FILENAME
-
 _env = jinja2.Environment(loader=jinja2.PackageLoader("pyscript"))
 
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -10,6 +10,7 @@ from typing import Any
 import pytest
 
 from pyscript import _generator as gen
+from pyscript import config
 
 
 def test_create_project(tmp_cwd: Path, is_not_none: Any) -> None:
@@ -19,7 +20,7 @@ def test_create_project(tmp_cwd: Path, is_not_none: Any) -> None:
     author_email = "acoder@domain.com"
     gen.create_project(app_name, app_description, author_name, author_email)
 
-    manifest_path = tmp_cwd / app_name / "manifest.json"
+    manifest_path = tmp_cwd / app_name / config["project_config_filename"]
     assert manifest_path.exists()
 
     with manifest_path.open() as fp:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-import toml
+import json
 
 from pyscript import _generator as gen
 
@@ -19,11 +19,11 @@ def test_create_project(tmp_cwd: Path, is_not_none: Any) -> None:
     author_email = "acoder@domain.com"
     gen.create_project(app_name, app_description, author_name, author_email)
 
-    manifest_path = tmp_cwd / app_name / "manifest.toml"
+    manifest_path = tmp_cwd / app_name / "manifest.json"
     assert manifest_path.exists()
 
     with manifest_path.open() as fp:
-        contents = toml.load(fp)
+        contents = json.load(fp)
 
     assert contents == {
         "name": "app_name",
@@ -31,7 +31,6 @@ def test_create_project(tmp_cwd: Path, is_not_none: Any) -> None:
         "type": "app",
         "author_name": "A.Coder",
         "author_email": "acoder@domain.com",
-        "created_on": is_not_none,
         "version": is_not_none,
     }
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -3,11 +3,11 @@ Tests for utility functions in the _generator.py module that cannot be
 exercised because of limitations in the Typer testing framework (specifically,
 multiple "prompt" arguments).
 """
+import json
 from pathlib import Path
 from typing import Any
 
 import pytest
-import json
 
 from pyscript import _generator as gen
 


### PR DESCRIPTION
This PR introduces two changes:

* As per our recent discussion, configuration is expressed as JSON not TOML.
* Update to tests to reflect this change.

That's it..!

(I removed "created_on" because we actually end up getting that from the API when the app is registered.)