### PR TITLE
Change config filenames

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     -   id: upgrade-type-hints
         args: [--futures=true]
 -   repo: https://github.com/pycqa/isort
-    rev: 5.11.1
+    rev: 5.11.4
     hooks:
     -   id: isort
         name: isort

--- a/src/pyscript/__init__.py
+++ b/src/pyscript/__init__.py
@@ -7,13 +7,13 @@ from rich.console import Console
 
 APPNAME = "pyscript"
 APPAUTHOR = "python"
-DEFAULT_CONFIG_FILENAME = "pyscript.json"
+DEFAULT_CONFIG_FILENAME = ".pyscriptconfig"
 
 
 # Default initial data for the command line.
 DEFAULT_CONFIG = {
     # Name of config file for PyScript projects.
-    "project_config_filename": "manifest.json",
+    "project_config_filename": "pyscript.toml",
 }
 
 

--- a/src/pyscript/_generator.py
+++ b/src/pyscript/_generator.py
@@ -2,8 +2,9 @@ import datetime
 import json
 from pathlib import Path
 from typing import Optional
-import toml
+
 import jinja2
+import toml
 
 from pyscript import config
 

--- a/src/pyscript/_generator.py
+++ b/src/pyscript/_generator.py
@@ -2,7 +2,7 @@ import datetime
 import json
 from pathlib import Path
 from typing import Optional
-
+import toml
 import jinja2
 
 from pyscript import config
@@ -50,6 +50,10 @@ def create_project(
     app_dir.mkdir()
     manifest_file = app_dir / config["project_config_filename"]
     with manifest_file.open("w", encoding="utf-8") as fp:
-        json.dump(context, fp)
+        if str(manifest_file).endswith(".json"):
+            json.dump(context, fp)
+        else:
+            toml.dump(context, fp)
+
     index_file = app_dir / "index.html"
     string_to_html('print("Hello, world!")', app_name, index_file)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -6,6 +6,7 @@ multiple "prompt" arguments).
 import json
 from pathlib import Path
 from typing import Any
+import toml
 
 import pytest
 
@@ -18,13 +19,20 @@ def test_create_project(tmp_cwd: Path, is_not_none: Any) -> None:
     app_description = "A longer, human friendly, app description."
     author_name = "A.Coder"
     author_email = "acoder@domain.com"
+
+    # GIVEN a a new project
     gen.create_project(app_name, app_description, author_name, author_email)
 
+    # with a default config path
     manifest_path = tmp_cwd / app_name / config["project_config_filename"]
+
+    # assert that the new project config file exists
     assert manifest_path.exists()
 
+    # assert that we can load it as a TOML file (TOML is the default config format)
+    # and that the contents of the config are as we expect
     with manifest_path.open() as fp:
-        contents = json.load(fp)
+        contents = toml.load(fp)
 
     assert contents == {
         "name": "app_name",

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -6,13 +6,12 @@ multiple "prompt" arguments).
 import json
 from pathlib import Path
 from typing import Any
-import toml
 
 import pytest
+import toml
 
 from pyscript import _generator as gen
 from pyscript import config
-
 
 TESTS_AUTHOR_NAME = "A.Coder"
 TESTS_AUTHOR_EMAIL = "acoder@domain.com"
@@ -21,8 +20,6 @@ TESTS_AUTHOR_EMAIL = "acoder@domain.com"
 def test_create_project(tmp_cwd: Path, is_not_none: Any) -> None:
     app_name = "app_name"
     app_description = "A longer, human friendly, app description."
-    author_name = "A.Coder"
-    author_email = "acoder@domain.com"
 
     # GIVEN a a new project
     gen.create_project(app_name, app_description, TESTS_AUTHOR_NAME, TESTS_AUTHOR_EMAIL)
@@ -40,16 +37,20 @@ def test_create_project_twice_raises_error(tmp_cwd: Path) -> None:
     gen.create_project(app_name, app_description, TESTS_AUTHOR_NAME, TESTS_AUTHOR_EMAIL)
 
     with pytest.raises(FileExistsError):
-        gen.create_project(app_name, app_description, TESTS_AUTHOR_NAME, TESTS_AUTHOR_EMAIL)
+        gen.create_project(
+            app_name, app_description, TESTS_AUTHOR_NAME, TESTS_AUTHOR_EMAIL
+        )
 
 
-def test_create_project_explicit_json(tmp_cwd: Path, is_not_none: Any, monkeypatch) -> None:
+def test_create_project_explicit_json(
+    tmp_cwd: Path, is_not_none: Any, monkeypatch
+) -> None:
     app_name = "JSON_app_name"
     app_description = "A longer, human friendly, app description."
 
     # Let's patch the config so that the project config file is a JSON file
-    config_file_name = 'pyscript.json'
-    monkeypatch.setitem(gen.config, 'project_config_filename', config_file_name)
+    config_file_name = "pyscript.json"
+    monkeypatch.setitem(gen.config, "project_config_filename", config_file_name)
 
     # GIVEN a new project
     gen.create_project(app_name, app_description, TESTS_AUTHOR_NAME, TESTS_AUTHOR_EMAIL)
@@ -60,13 +61,15 @@ def test_create_project_explicit_json(tmp_cwd: Path, is_not_none: Any, monkeypat
     check_project_manifest(manifest_path, json, app_name, is_not_none)
 
 
-def test_create_project_explicit_toml(tmp_cwd: Path, is_not_none: Any, monkeypatch) -> None:
+def test_create_project_explicit_toml(
+    tmp_cwd: Path, is_not_none: Any, monkeypatch
+) -> None:
     app_name = "TOML_app_name"
     app_description = "A longer, human friendly, app description."
 
     # Let's patch the config so that the project config file is a JSON file
-    config_file_name = 'mypyscript.toml'
-    monkeypatch.setitem(gen.config, 'project_config_filename', config_file_name)
+    config_file_name = "mypyscript.toml"
+    monkeypatch.setitem(gen.config, "project_config_filename", config_file_name)
 
     # GIVEN a new project
     gen.create_project(app_name, app_description, TESTS_AUTHOR_NAME, TESTS_AUTHOR_EMAIL)
@@ -76,11 +79,17 @@ def test_create_project_explicit_toml(tmp_cwd: Path, is_not_none: Any, monkeypat
 
     check_project_manifest(manifest_path, toml, app_name, is_not_none)
 
+
 def check_project_manifest(
-    config_path: Path, serializer: Any, app_name: str, is_not_none: Any,
+    config_path: Path,
+    serializer: Any,
+    app_name: str,
+    is_not_none: Any,
     app_description: str = "A longer, human friendly, app description.",
-    author_name: str = TESTS_AUTHOR_NAME, author_email: str = TESTS_AUTHOR_EMAIL ,
-    project_type: str = "app"):
+    author_name: str = TESTS_AUTHOR_NAME,
+    author_email: str = TESTS_AUTHOR_EMAIL,
+    project_type: str = "app",
+):
     """
     Perform the following:
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -14,6 +14,10 @@ from pyscript import _generator as gen
 from pyscript import config
 
 
+TESTS_AUTHOR_NAME = "A.Coder"
+TESTS_AUTHOR_EMAIL = "acoder@domain.com"
+
+
 def test_create_project(tmp_cwd: Path, is_not_none: Any) -> None:
     app_name = "app_name"
     app_description = "A longer, human friendly, app description."
@@ -21,87 +25,51 @@ def test_create_project(tmp_cwd: Path, is_not_none: Any) -> None:
     author_email = "acoder@domain.com"
 
     # GIVEN a a new project
-    gen.create_project(app_name, app_description, author_name, author_email)
+    gen.create_project(app_name, app_description, TESTS_AUTHOR_NAME, TESTS_AUTHOR_EMAIL)
 
     # with a default config path
     manifest_path = tmp_cwd / app_name / config["project_config_filename"]
 
-    # assert that the new project config file exists
-    assert manifest_path.exists()
-
-    # assert that we can load it as a TOML file (TOML is the default config format)
-    # and that the contents of the config are as we expect
-    with manifest_path.open() as fp:
-        contents = toml.load(fp)
-
-    assert contents == {
-        "name": "app_name",
-        "description": "A longer, human friendly, app description.",
-        "type": "app",
-        "author_name": "A.Coder",
-        "author_email": "acoder@domain.com",
-        "version": is_not_none,
-    }
+    check_project_manifest(manifest_path, toml, app_name, is_not_none)
 
 
 def test_create_project_twice_raises_error(tmp_cwd: Path) -> None:
     """We get a FileExistsError when we try to create an existing project."""
     app_name = "app_name"
     app_description = "A longer, human friendly, app description."
-    author_name = "A.Coder"
-    author_email = "acoder@domain.com"
-    gen.create_project(app_name, app_description, author_name, author_email)
+    gen.create_project(app_name, app_description, TESTS_AUTHOR_NAME, TESTS_AUTHOR_EMAIL)
 
     with pytest.raises(FileExistsError):
-        gen.create_project(app_name, app_description, author_name, author_email)
+        gen.create_project(app_name, app_description, TESTS_AUTHOR_NAME, TESTS_AUTHOR_EMAIL)
 
 
 def test_create_project_explicit_json(tmp_cwd: Path, is_not_none: Any, monkeypatch) -> None:
     app_name = "JSON_app_name"
     app_description = "A longer, human friendly, app description."
-    author_name = "A.Coder"
-    author_email = "acoder@domain.com"
 
     # Let's patch the config so that the project config file is a JSON file
     config_file_name = 'pyscript.json'
     monkeypatch.setitem(gen.config, 'project_config_filename', config_file_name)
 
     # GIVEN a new project
-    gen.create_project(app_name, app_description, author_name, author_email)
+    gen.create_project(app_name, app_description, TESTS_AUTHOR_NAME, TESTS_AUTHOR_EMAIL)
 
     # get the path where the config file is being created
     manifest_path = tmp_cwd / app_name / config["project_config_filename"]
 
-    # assert that the new project config file exists
-    assert manifest_path.exists()
-
-    # assert that we can load it as a TOML file (TOML is the default config format)
-    # and that the contents of the config are as we expect
-    with manifest_path.open() as fp:
-        contents = json.load(fp)
-
-    assert contents == {
-        "name": "JSON_app_name",
-        "description": app_description,
-        "type": "app",
-        "author_name": author_name,
-        "author_email": author_email,
-        "version": is_not_none,
-    }
+    check_project_manifest(manifest_path, json, app_name, is_not_none)
 
 
 def test_create_project_explicit_toml(tmp_cwd: Path, is_not_none: Any, monkeypatch) -> None:
     app_name = "TOML_app_name"
     app_description = "A longer, human friendly, app description."
-    author_name = "A.Coder"
-    author_email = "acoder@domain.com"
 
     # Let's patch the config so that the project config file is a JSON file
     config_file_name = 'mypyscript.toml'
     monkeypatch.setitem(gen.config, 'project_config_filename', config_file_name)
 
     # GIVEN a new project
-    gen.create_project(app_name, app_description, author_name, author_email)
+    gen.create_project(app_name, app_description, TESTS_AUTHOR_NAME, TESTS_AUTHOR_EMAIL)
 
     # get the path where the config file is being created
     manifest_path = tmp_cwd / app_name / config["project_config_filename"]
@@ -111,7 +79,7 @@ def test_create_project_explicit_toml(tmp_cwd: Path, is_not_none: Any, monkeypat
 def check_project_manifest(
     config_path: Path, serializer: Any, app_name: str, is_not_none: Any,
     app_description: str = "A longer, human friendly, app description.",
-    author_name: str = "A.Coder", author_email: str = "acoder@domain.com",
+    author_name: str = TESTS_AUTHOR_NAME, author_email: str = TESTS_AUTHOR_EMAIL ,
     project_type: str = "app"):
     """
     Perform the following:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -110,7 +110,7 @@ def test_create_project_explicit_toml(tmp_cwd: Path, is_not_none: Any, monkeypat
 
 def check_project_manifest(
     config_path: Path, serializer: Any, app_name: str, is_not_none: Any,
-    app_description: str = "A longer, human friendly, app description.", 
+    app_description: str = "A longer, human friendly, app description.",
     author_name: str = "A.Coder", author_email: str = "acoder@domain.com",
     project_type: str = "app"):
     """

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -54,3 +54,103 @@ def test_create_project_twice_raises_error(tmp_cwd: Path) -> None:
 
     with pytest.raises(FileExistsError):
         gen.create_project(app_name, app_description, author_name, author_email)
+
+
+def test_create_project_explicit_json(tmp_cwd: Path, is_not_none: Any, monkeypatch) -> None:
+    app_name = "JSON_app_name"
+    app_description = "A longer, human friendly, app description."
+    author_name = "A.Coder"
+    author_email = "acoder@domain.com"
+
+    # Let's patch the config so that the project config file is a JSON file
+    config_file_name = 'pyscript.json'
+    monkeypatch.setitem(gen.config, 'project_config_filename', config_file_name)
+
+    # GIVEN a new project
+    gen.create_project(app_name, app_description, author_name, author_email)
+
+    # get the path where the config file is being created
+    manifest_path = tmp_cwd / app_name / config["project_config_filename"]
+
+    # assert that the new project config file exists
+    assert manifest_path.exists()
+
+    # assert that we can load it as a TOML file (TOML is the default config format)
+    # and that the contents of the config are as we expect
+    with manifest_path.open() as fp:
+        contents = json.load(fp)
+
+    assert contents == {
+        "name": "JSON_app_name",
+        "description": app_description,
+        "type": "app",
+        "author_name": author_name,
+        "author_email": author_email,
+        "version": is_not_none,
+    }
+
+
+def test_create_project_explicit_toml(tmp_cwd: Path, is_not_none: Any, monkeypatch) -> None:
+    app_name = "TOML_app_name"
+    app_description = "A longer, human friendly, app description."
+    author_name = "A.Coder"
+    author_email = "acoder@domain.com"
+
+    # Let's patch the config so that the project config file is a JSON file
+    config_file_name = 'mypyscript.toml'
+    monkeypatch.setitem(gen.config, 'project_config_filename', config_file_name)
+
+    # GIVEN a new project
+    gen.create_project(app_name, app_description, author_name, author_email)
+
+    # get the path where the config file is being created
+    manifest_path = tmp_cwd / app_name / config["project_config_filename"]
+
+    check_project_manifest(manifest_path, toml, app_name, is_not_none)
+
+def check_project_manifest(
+    config_path: Path, serializer: Any, app_name: str, is_not_none: Any,
+    app_description: str = "A longer, human friendly, app description.", 
+    author_name: str = "A.Coder", author_email: str = "acoder@domain.com",
+    project_type: str = "app"):
+    """
+    Perform the following:
+
+        * checks that `config_path` exists
+        * loads the contents of `config_path` using `serializer.load`
+        * check that the contents match with the values provided in input. Specifically:
+            * "name" == app_name
+            * "description" == app_description
+            * "type" == app_type
+            * "author_name" == author_name
+            * "author_email" == author_email
+            * "version" == is_not_none
+
+    Params:
+        * config_path(Path): path to the app config file
+        * serializer(json|toml): serializer to be used to load contents of `config_path`.
+                                 Supported values are either modules `json` or `toml`
+        * app_name(str): name of application
+        * is_not_none(any): pytest fixture
+        * app_description(str): application description
+        * author_name(str): application author name
+        * author_email(str): application author email
+        * project_type(str): project type
+
+    """
+    # assert that the new project config file exists
+    assert config_path.exists()
+
+    # assert that we can load it as a TOML file (TOML is the default config format)
+    # and that the contents of the config are as we expect
+    with config_path.open() as fp:
+        contents = serializer.load(fp)
+
+    assert contents == {
+        "name": app_name,
+        "description": app_description,
+        "type": project_type,
+        "author_name": author_name,
+        "author_email": author_email,
+        "version": is_not_none,
+    }


### PR DESCRIPTION
Close #39 

Basically:

* renames global pyscript config `pyscript.json` --> `.pyscriptconfig`
* renames default app config `manifest.json` --> `pyscript.toml`
* supports app config as `json` or `toml`