### PR TITLE
Disable pretty-format-toml until upstream is fixed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,11 @@ repos:
     hooks:
     -   id: pretty-format-yaml
         args: [--autofix, --indent, '4']
-    -   id: pretty-format-toml
-        args: [--autofix]
+# TODO: This formatter is broken due to a sub-dependency
+# It should be fixed in a future release but for now, ignore TOML file formatting
+# See: https://github.com/macisamuele/language-formatters-pre-commit-hooks/issues/133
+#    -   id: pretty-format-toml
+#        args: [--autofix]
 -   repo: https://github.com/sondrelg/pep585-upgrade
     rev: v1.0
     hooks:


### PR DESCRIPTION
Addresses #51.

There is a bug in a sub-dependency of the upstream pre-commit hook (see macisamuele/language-formatters-pre-commit-hooks#133), which was not caused by our own dependency upgrade but which is causing all pipelines to fail.


This PR disables this pre-commit hook until the upstream can be fixed.
