### PR TITLE
fix dev install docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,28 +4,32 @@
 
 Git clone the repository:
 
-```
+```shell
 git clone https://github.com/pyscript/pyscript.git
 ```
 
 (Recommended) Upgrade local pip:
 
-```
+```shell
 pip install --upgrade pip
 ```
 
 Make a virtualenv and activate it:
 
-```
+```shell
 python -m venv .venv
 . .venv/bin/activate
 ```
 
 Install your local enviroment dependencies
 
-```
+```shell
 pip install -e ".[dev]"
 ```
+
+## Use the CLI
+
+It is now possible to normally use the CLI. For more information on how to use it and it's commands, see the [Use the CLI section of the README](README.md)
 
 ## Run the tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,21 @@
 # Contribution guide for developers
 
+## Developer setup
+
+Git clone the repository:
+
+```
+git clone https://github.com/pyscript/pyscript.git
+```
+
+(Recommended) Upgrade local pip:
+
+```
+pip install --upgrade pip
+```
+
+
+
 ## Documentation
 
 ### Install the documentation dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,11 @@ pip install -e ".[dev]"
 
 ## Run the tests
 
-After setting up your developer enviroment, you can run the tests with the following command
+After setting up your developer enviroment, you can run the tests with the following command from the root directory:
+
+```shell
+pytest .
+```
 
 ## Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,10 @@ Install your local enviroment dependencies
 pip install -e ".[dev]"
 ```
 
+## Run the tests
+
+After setting up your developer enviroment, you can run the tests with the following command
+
 ## Documentation
 
 ### Install the documentation dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,18 @@ git clone https://github.com/pyscript/pyscript.git
 pip install --upgrade pip
 ```
 
+Make a virtualenv and activate it:
 
+```
+python -m venv .venv
+. .venv/bin/activate
+```
+
+Install your local enviroment dependencies
+
+```
+pip install -e ".[dev]"
+```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,16 @@ Quickly wrap Python scripts into a HTML template, pre-configured with [PyScript]
 
 ## Installation
 
+### Using Pip
+
 ```shell
 $ pip install pyscript
 ```
+
+### Installing the developer setup from the a repository clone
+
+
+[see the Developer setup section on CONTRIBUTING page](CONTRIBUTING.md)
 
 ## Usage
 


### PR DESCRIPTION
This PR fixes the dev instructions that were not updated after we switched from poetry to setuptools #64