### PR TITLE
set cors when running web server

### DIFF
--- a/src/pyscript/plugins/run.py
+++ b/src/pyscript/plugins/run.py
@@ -30,6 +30,11 @@ def get_folder_based_http_request_handler(
         def __init__(self, *args, **kwargs):
             super().__init__(*args, directory=folder, **kwargs)
 
+        def end_headers(self):
+            self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+            self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+            SimpleHTTPRequestHandler.end_headers(self)
+
     return FolderBasedHTTPRequestHandler
 
 

--- a/src/pyscript/plugins/run.py
+++ b/src/pyscript/plugins/run.py
@@ -33,6 +33,7 @@ def get_folder_based_http_request_handler(
         def end_headers(self):
             self.send_header("Cross-Origin-Opener-Policy", "same-origin")
             self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+            self.send_header("Cross-Origin-Resource-Policy", "cross-origin")
             SimpleHTTPRequestHandler.end_headers(self)
 
     return FolderBasedHTTPRequestHandler


### PR DESCRIPTION
For PyScript to run when we run `pyscript run` we need to set the right CORS . This PR Addresses that