### PR TITLE
Allow description, name and email to be empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ coverage.xml
 # Generated documentation
 /docs/build/
 /docs/source/api/
+
+pyscript.egg-info/
+build/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 # This is the configuration for pre-commit, a local framework for managing pre-commit hooks
 #   Check out the docs at: https://pre-commit.com/
+ci:
+    #skip: [eslint]
+    autoupdate_schedule: monthly
 
+default_stages: [commit]
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -23,6 +27,7 @@ repos:
     hooks:
     -   id: isort
         name: isort (python)
+        args: [--profile, black]
 -   repo: https://github.com/psf/black
     rev: 24.2.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,32 +3,31 @@
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.10.0
+    rev: v2.12.0
     hooks:
     -   id: pretty-format-yaml
         args: [--autofix, --indent, '4']
     -   id: pretty-format-toml
         args: [--autofix]
--   repo: https://github.com/sondrelg/pep585-upgrade
-    rev: v1.0
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.15.0
     hooks:
-    -   id: upgrade-type-hints
-        args: [--futures=true]
+    -   id: pyupgrade
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
     -   id: isort
-        name: isort
+        name: isort (python)
 -   repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.2.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
     -   id: flake8

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,5 @@
 """Documentation configuration for `pyscript-cli`."""
+
 from __future__ import annotations
 
 import sys

--- a/src/pyscript/__init__.py
+++ b/src/pyscript/__init__.py
@@ -1,4 +1,5 @@
 """A CLI for PyScript!"""
+
 import json
 from pathlib import Path
 

--- a/src/pyscript/cli.py
+++ b/src/pyscript/cli.py
@@ -1,4 +1,5 @@
 """The main CLI entrypoint and commands."""
+
 import sys
 from typing import Any, Optional
 

--- a/src/pyscript/plugins/create.py
+++ b/src/pyscript/plugins/create.py
@@ -63,11 +63,11 @@ def create(
         )
 
     if not app_description:
-        app_description = typer.prompt("App description")
+        app_description = typer.prompt("App description", default="")
     if not author_name:
-        author_name = typer.prompt("Author name")
+        author_name = typer.prompt("Author name", default="")
     if not author_email:
-        author_email = typer.prompt("Author email")
+        author_email = typer.prompt("Author email", default="")
 
     try:
         create_project(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,18 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
 
+@pytest.fixture
+def auto_enter(monkeypatch):
+    """
+    Monkey patch 'typer.confirm' to always hit <Enter>".
+    """
+
+    def user_hit_enter(*args, **kwargs):
+        return ""
+
+    monkeypatch.setattr("typer.prompt", user_hit_enter)
+
+
 @pytest.fixture()
 def tmp_cwd(monkeypatch: MonkeyPatch, tmp_path: Path) -> Path:
     """Create & return a temporary directory after setting current working directory to it."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,6 +48,30 @@ def test_version() -> None:
     assert f"PyScript CLI version: {__version__}" in result.stdout
 
 
+def test_create_command(
+    invoke_cli: CLIInvoker, tmp_path: Path, app_details_args: list[str]
+) -> None:
+    result = invoke_cli("create", "myapp")
+    assert result.exit_code == 0
+
+    expected_path = tmp_path / "myapp"
+    assert expected_path.exists()
+
+    expected_main_py_path = expected_path / "main.py"
+    assert expected_main_py_path.exists()
+
+    expected_config_path = expected_path / config["project_config_filename"]
+    assert expected_config_path.exists()
+    with expected_config_path.open() as fp:
+        config_text = fp.read()
+
+    assert 'name = "myapp' in config_text
+    # Assert that description, author name and email are empty
+    assert 'description = ""' in config_text
+    assert 'author_name = ""' in config_text
+    assert 'author_email = ""' in config_text
+
+
 @pytest.mark.parametrize("flag", ["-c", "--command"])
 def test_wrap_command(
     invoke_cli: CLIInvoker, tmp_path: Path, flag: str, app_details_args: list[str]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Callable
 
 import pytest
 from mypy_extensions import VarArg
@@ -29,7 +29,7 @@ def app_details_args():
 
 
 @pytest.fixture()
-def invoke_cli(tmp_path: Path, monkeypatch: "MonkeyPatch") -> CLIInvoker:
+def invoke_cli(tmp_path: Path, monkeypatch: MonkeyPatch) -> CLIInvoker:
     """Returns a function, which can be used to call the CLI from within a temporary directory."""
     runner = CliRunner()
 
@@ -49,7 +49,7 @@ def test_version() -> None:
 
 
 def test_create_command(
-    invoke_cli: CLIInvoker, tmp_path: Path, app_details_args: list[str]
+    invoke_cli: CLIInvoker, tmp_path: Path, app_details_args: list[str], auto_enter
 ) -> None:
     result = invoke_cli("create", "myapp")
     assert result.exit_code == 0
@@ -140,7 +140,7 @@ def test_wrap_file(
 )
 def test_wrap_pyscript_version(
     invoke_cli: CLIInvoker,
-    version: Optional[str],
+    version: str | None,
     expected_version: str,
     tmp_path: Path,
     app_details_args: list[str],
@@ -190,7 +190,7 @@ def test_wrap_pyscript_version(
 )
 def test_wrap_pyscript_version_file(
     invoke_cli: CLIInvoker,
-    version: Optional[str],
+    version: str | None,
     expected_version: str,
     tmp_path: Path,
     app_details_args: list[str],

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -3,6 +3,7 @@ Tests for utility functions in the _generator.py module that cannot be
 exercised because of limitations in the Typer testing framework (specifically,
 multiple "prompt" arguments).
 """
+
 import json
 from pathlib import Path
 from textwrap import dedent

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,7 +16,7 @@ CLIInvoker = Callable[[VarArg(str)], Result]
 
 
 @pytest.fixture()
-def invoke_cli(tmp_path: Path, monkeypatch: "MonkeyPatch") -> CLIInvoker:
+def invoke_cli(tmp_path: Path, monkeypatch: MonkeyPatch) -> CLIInvoker:
     """Returns a function, which can be used to call the CLI from within a temporary directory."""
     runner = CliRunner()
 


### PR DESCRIPTION
Seems like the create command keeps asking user for name, description and email if the user presses enter to skip it. This PR makes sure that users can now skip these config values and default to an empty string.